### PR TITLE
Add monitoring stack with Grafana and Prometheus

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,12 @@
 output "web_public_ip" { value = aws_eip.web_eip.public_ip }
+output "monitoring_public_ip" { value = aws_instance.monitoring.public_ip }
 output "web_private_ip" { value = aws_instance.web.private_ip }
 output "db_private_ip" { value = aws_instance.db.private_ip }
 output "private_zone_name" { value = aws_route53_zone.private.name }
-output "private_records" { value = { web = aws_route53_record.web_a.name, db = aws_route53_record.db_a.name } }
+output "private_records" {
+  value = {
+    web        = aws_route53_record.web_a.name
+    db         = aws_route53_record.db_a.name
+    monitoring = aws_route53_record.monitoring_a.name
+  }
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -7,6 +7,7 @@ public_subnet_cidr  = "10.11.5.192/26"
 private_subnet_cidr = "10.11.5.0/26"
 instance_type_web   = "t2.micro"
 instance_type_db    = "t2.micro"
+instance_type_monitoring = "t3.medium"
 
 # App / Domain / Defaults
 app_zip_url         = "https://raw.githubusercontent.com/marchaenni/terraform-ecommerce/main/01_Flask-Python-E-Commerce-Website.zip"

--- a/userdata/monitoring_cloud_init.yaml.tftpl
+++ b/userdata/monitoring_cloud_init.yaml.tftpl
@@ -1,0 +1,105 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - docker.io
+  - docker-compose
+
+write_files:
+  - path: ${stack_dir}/docker-compose.yml
+    owner: ubuntu:ubuntu
+    permissions: "0644"
+    content: |
+      version: "3.8"
+
+      services:
+        prometheus:
+          image: prom/prometheus:v2.49.1
+          restart: unless-stopped
+          ports:
+            - "9090:9090"
+          command:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=7d"
+          volumes:
+            - ./prometheus:/etc/prometheus
+            - prometheus_data:/prometheus
+
+        grafana:
+          image: grafana/grafana:10.4.2
+          restart: unless-stopped
+          depends_on:
+            - prometheus
+          ports:
+            - "3000:3000"
+          environment:
+            - GF_SECURITY_ADMIN_USER=admin
+            - GF_SECURITY_ADMIN_PASSWORD=admin
+            - GF_USERS_ALLOW_SIGN_UP=false
+          volumes:
+            - grafana_data:/var/lib/grafana
+            - ./grafana/provisioning:/etc/grafana/provisioning
+
+      volumes:
+        prometheus_data:
+        grafana_data:
+
+  - path: ${stack_dir}/prometheus/prometheus.yml
+    owner: ubuntu:ubuntu
+    permissions: "0644"
+    content: |
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+
+      scrape_configs:
+        - job_name: "prometheus"
+          static_configs:
+            - targets:
+                - "localhost:9090"
+
+        - job_name: "webserver-node"
+          static_configs:
+            - targets:
+                - "${web_host_fqdn}:9100"
+
+  - path: ${stack_dir}/grafana/provisioning/datasources/datasource.yml
+    owner: ubuntu:ubuntu
+    permissions: "0644"
+    content: |
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          url: http://prometheus:9090
+          isDefault: true
+          editable: false
+
+  - path: /etc/systemd/system/monitoring.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Grafana, Prometheus Docker Compose Service
+      After=network.target docker.service
+      Requires=docker.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      WorkingDirectory=${stack_dir}
+      ExecStart=/usr/bin/docker-compose up -d
+      ExecStop=/usr/bin/docker-compose down
+      TimeoutStartSec=0
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - [usermod, -aG, docker, ubuntu]
+  - [bash, -lc, "mkdir -p ${stack_parent}"]
+  - [bash, -lc, "chown -R ubuntu:ubuntu ${stack_parent}"]
+  - [systemctl, daemon-reload]
+  - [systemctl, enable, --now, monitoring.service]

--- a/userdata/web_cloud_init.yaml.tftpl
+++ b/userdata/web_cloud_init.yaml.tftpl
@@ -14,6 +14,7 @@ packages:
   - libmariadb-dev-compat
   - apache2-utils
   - unzip
+  - prometheus-node-exporter
 
 write_files:
   - path: /etc/systemd/system/ecommerce.service

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,11 @@ variable "instance_type_db" {
   default = "t2.micro"
 }
 
+variable "instance_type_monitoring" {
+  type    = string
+  default = "t3.medium"
+}
+
 variable "domain_name" {
   type    = string
   default = "webshop.tbz"


### PR DESCRIPTION
## Summary
- add a monitoring security group and EC2 instance that bootstraps Grafana and Prometheus via docker-compose and a systemd service
- publish a private Route53 record plus public outputs for the monitoring host
- expose configuration for the monitoring instance type and enable node-exporter metrics scraping from the web server

## Testing
- terraform fmt *(fails: Terraform CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3a61825c48325b8d2ad0d9fae654c