### PR TITLE
Ensure monitoring stack directories exist in cloud-init

### DIFF
--- a/userdata/monitoring_cloud_init.yaml.tftpl
+++ b/userdata/monitoring_cloud_init.yaml.tftpl
@@ -5,6 +5,13 @@ packages:
   - docker.io
   - docker-compose
 
+bootcmd:
+  - [mkdir, -p, ${stack_dir}]
+  - [mkdir, -p, ${stack_dir}/prometheus]
+  - [mkdir, -p, ${stack_dir}/grafana]
+  - [mkdir, -p, ${stack_dir}/grafana/provisioning]
+  - [mkdir, -p, ${stack_dir}/grafana/provisioning/datasources]
+
 write_files:
   - path: ${stack_dir}/docker-compose.yml
     owner: ubuntu:ubuntu


### PR DESCRIPTION
## Summary
- create the monitoring stack directory structure during boot to avoid write_files failures
- keep the existing docker-compose setup so Grafana and Prometheus start via systemd

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d3ad3defc08325a07044ca7f0f9f26