### PR TITLE
Fix monitoring cloud-init ownership and docker startup

### DIFF
--- a/userdata/monitoring_cloud_init.yaml.tftpl
+++ b/userdata/monitoring_cloud_init.yaml.tftpl
@@ -14,7 +14,7 @@ bootcmd:
 
 write_files:
   - path: ${stack_dir}/docker-compose.yml
-    owner: ubuntu:ubuntu
+    owner: root:root
     permissions: "0644"
     content: |
       version: "3.8"
@@ -53,7 +53,7 @@ write_files:
         grafana_data:
 
   - path: ${stack_dir}/prometheus/prometheus.yml
-    owner: ubuntu:ubuntu
+    owner: root:root
     permissions: "0644"
     content: |
       global:
@@ -72,7 +72,7 @@ write_files:
                 - "${web_host_fqdn}:9100"
 
   - path: ${stack_dir}/grafana/provisioning/datasources/datasource.yml
-    owner: ubuntu:ubuntu
+    owner: root:root
     permissions: "0644"
     content: |
       apiVersion: 1
@@ -108,5 +108,7 @@ runcmd:
   - [usermod, -aG, docker, ubuntu]
   - [bash, -lc, "mkdir -p ${stack_parent}"]
   - [bash, -lc, "chown -R ubuntu:ubuntu ${stack_parent}"]
+  - [systemctl, enable, --now, docker]
+  - [bash, -lc, "until systemctl is-active --quiet docker; do sleep 2; done"]
   - [systemctl, daemon-reload]
   - [systemctl, enable, --now, monitoring.service]


### PR DESCRIPTION
## Summary
- update monitoring cloud-init templates to avoid referencing the ubuntu user before it exists
- enable and wait for the docker service before starting the monitoring stack to prevent race conditions

## Testing
- ⚠️ `terraform fmt -check` *(fails: terraform not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3af92b8b883259d659032dba9cec9